### PR TITLE
The `ntpd` command was removed from Mojave.

### DIFF
--- a/Sketch Runner.applescript
+++ b/Sketch Runner.applescript
@@ -1,3 +1,3 @@
 do shell script "date 0101000000" with administrator privileges
 do shell script "open -a Sketch"
-do shell script "ntpd -gq" with administrator privileges
+do shell script "sntp -sS time.apple.com" with administrator privileges


### PR DESCRIPTION
I'm using 10.14 Mac Mojave GM, and looks like `NTPD` command was removed from the OS. 
Hereby i propose to change `ntpd` to `sntp` for people on MacOS 10.14 or higher