### PR TITLE
On slower computers script wasn't waiting for Sketch to launch.

### DIFF
--- a/Sketch Runner.applescript
+++ b/Sketch Runner.applescript
@@ -1,3 +1,12 @@
 do shell script "date 0101120000" with administrator privileges
-do shell script "open -a Sketch"
+
+tell application "Sketch"
+	activate
+	
+	# Wait until Sketch starts
+	repeat until it is running
+		delay 0.1
+	end repeat
+end tell
+
 do shell script "sntp -sS time.apple.com" with administrator privileges


### PR DESCRIPTION
On slower computers script wasn't waiting for Sketch to launch.
Modified script in order to achieve this.

Script will wait for Sketch to fully initialize before setting time back to normal.